### PR TITLE
lock HeliumLogger minor version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "kitura-helloworld",
 	dependencies: [
-    .Package(url: "https://github.com/IBM-Swift/HeliumLogger.git", majorVersion: 1),
+    .Package(url: "https://github.com/IBM-Swift/HeliumLogger.git", majorVersion: 1, minor: 6),
     .Package(url: "https://github.com/IBM-Swift/Kitura.git", majorVersion: 1, minor: 6),
     .Package(url: "https://github.com/IBM-Swift/CloudConfiguration.git", majorVersion: 1),
     .Package(url: "https://github.com/IBM-Swift/Kitura-CouchDB.git", majorVersion: 1, minor: 6)


### PR DESCRIPTION
HeliumLogger version v1.7 takes a dependency on LoggerAPI v1.7 which conflicts with the LoggerAPI dependency used by Kitura v1.6 and causes the application to fail staging.  Locking the HeliumLogger dependency to v1.6 will fix this.