### PR TITLE
Added showcasing of userprovided services 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,124 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CCurl",
+        "repositoryURL": "https://github.com/IBM-Swift/CCurl.git",
+        "state": {
+          "branch": null,
+          "revision": "f481bd86e58787824cc1c1ec1786e03b67831f38",
+          "version": "0.4.1"
+        }
+      },
+      {
+        "package": "CloudEnvironment",
+        "repositoryURL": "https://github.com/IBM-Swift/CloudEnvironment.git",
+        "state": {
+          "branch": null,
+          "revision": "1100268ee17670fd320b0d9463a66e13ca24755f",
+          "version": "4.0.5"
+        }
+      },
+      {
+        "package": "CloudFoundryEnv",
+        "repositoryURL": "https://github.com/IBM-Swift/Swift-cfenv.git",
+        "state": {
+          "branch": null,
+          "revision": "6ded559c54871fd7a94a0c7fabe51e096bb1e392",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "package": "Configuration",
+        "repositoryURL": "https://github.com/IBM-Swift/Configuration.git",
+        "state": {
+          "branch": null,
+          "revision": "9973bcc64f41c81c9716bf1306079be61f29c998",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "HeliumLogger",
+        "repositoryURL": "https://github.com/IBM-Swift/HeliumLogger.git",
+        "state": {
+          "branch": null,
+          "revision": "2afeb4c02f5a48a7fbd081fe8607b91eeebd7ecb",
+          "version": "1.7.1"
+        }
+      },
+      {
+        "package": "Kitura",
+        "repositoryURL": "https://github.com/IBM-Swift/Kitura.git",
+        "state": {
+          "branch": null,
+          "revision": "e02c756134c5b399cfc45f186bc2c6f1d51032d1",
+          "version": "1.7.9"
+        }
+      },
+      {
+        "package": "Kitura-CouchDB",
+        "repositoryURL": "https://github.com/IBM-Swift/Kitura-CouchDB.git",
+        "state": {
+          "branch": null,
+          "revision": "dcdc61061553306226c92768c3b44485379e39a7",
+          "version": "1.7.2"
+        }
+      },
+      {
+        "package": "Kitura-TemplateEngine",
+        "repositoryURL": "https://github.com/IBM-Swift/Kitura-TemplateEngine.git",
+        "state": {
+          "branch": null,
+          "revision": "8e75a213bf4dd7b5effd03848335e344535969aa",
+          "version": "1.7.2"
+        }
+      },
+      {
+        "package": "Kitura-net",
+        "repositoryURL": "https://github.com/IBM-Swift/Kitura-net.git",
+        "state": {
+          "branch": null,
+          "revision": "e04ee59e93b72ffb19c730d80dac4e15d060a5da",
+          "version": "1.7.18"
+        }
+      },
+      {
+        "package": "LoggerAPI",
+        "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
+        "state": {
+          "branch": null,
+          "revision": "6b62fe66da9b8794d6581e5c341710eea3173cd4",
+          "version": "1.7.1"
+        }
+      },
+      {
+        "package": "SSLService",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueSSLService.git",
+        "state": {
+          "branch": null,
+          "revision": "7adf7cacc447d447df5dcc3058cabd402177c5aa",
+          "version": "0.12.64"
+        }
+      },
+      {
+        "package": "Socket",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueSocket.git",
+        "state": {
+          "branch": null,
+          "revision": "00b126a2c19520bbf51cd26e8c0cc41dacbc5a05",
+          "version": "0.12.76"
+        }
+      },
+      {
+        "package": "SwiftyJSON",
+        "repositoryURL": "https://github.com/IBM-Swift/SwiftyJSON.git",
+        "state": {
+          "branch": null,
+          "revision": "1190845cf7d25a5c8ea7653fe03dcdd39a082056",
+          "version": "17.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ We're now going to update your local code to point to this database. Create a JS
  }
  ```
 
-Update the `mappings.json` file in the `config` directory by replacing the `<cloudant instance name>` placeholder with the **name** that was assigned to your Cloudant instance:
+Update the `mappings.json` file in the `config` directory by replacing the `clodant` placeholder with the **name** that was assigned to your Cloudant instance:
 
 ```
 {
   "MyCloudantDB": {
     "searchPatterns": [
-      "cloudfoundry:<cloudant instance name>",
+      "cloudfoundry:cloudant",
       "env:kube-cloudant-credentials",
       "file:config/my-cloudant-credentials.json"
     ]

--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -36,7 +36,6 @@ class Controller {
     cloudEnv = CloudEnv()
     let cloudantCredentials = cloudEnv.getCloudantCredentials(name: "MyCloudantDB")
     dbMgr = DatabaseManager(dbName: dbName, credentials: cloudantCredentials)
-    // Log.info("dbMgr: \(String(reflecting: dbMgr))")
 
     // All web apps need a Router instance to define routes
     router = Router()

--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -36,6 +36,7 @@ class Controller {
     cloudEnv = CloudEnv()
     let cloudantCredentials = cloudEnv.getCloudantCredentials(name: "MyCloudantDB")
     dbMgr = DatabaseManager(dbName: dbName, credentials: cloudantCredentials)
+    // Log.info("dbMgr: \(String(reflecting: dbMgr))")
 
     // All web apps need a Router instance to define routes
     router = Router()

--- a/config/mappings.json
+++ b/config/mappings.json
@@ -1,7 +1,6 @@
 {
   "MyCloudantDB": {
     "searchPatterns": [
-      "cloudfoundry:<cloudant instance name>",
       "cloudfoundry:cloudant",
       "env:kube-cloudant-credentials",
       "file:config/my-cloudant-credentials.json"

--- a/config/mappings.json
+++ b/config/mappings.json
@@ -2,6 +2,7 @@
   "MyCloudantDB": {
     "searchPatterns": [
       "cloudfoundry:<cloudant instance name>",
+      "cloudfoundry:cloudant",
       "env:kube-cloudant-credentials",
       "file:config/my-cloudant-credentials.json"
     ]

--- a/config/mappings.json
+++ b/config/mappings.json
@@ -2,7 +2,7 @@
   "MyCloudantDB": {
     "searchPatterns": [
       "cloudfoundry:cloudant",
-      "env:kube-cloudant-credentials",
+      "env:kube_cloudant_credentials",
       "file:config/my-cloudant-credentials.json"
     ]
   }

--- a/config/mappings.json
+++ b/config/mappings.json
@@ -2,7 +2,7 @@
   "MyCloudantDB": {
     "searchPatterns": [
       "cloudfoundry:<cloudant instance name>",
-      "cloudfoundry:cloudant",
+      "cloudfoundry:/cloudant/",
       "env:kube-cloudant-credentials",
       "file:config/my-cloudant-credentials.json"
     ]

--- a/config/mappings.json
+++ b/config/mappings.json
@@ -2,7 +2,7 @@
   "MyCloudantDB": {
     "searchPatterns": [
       "cloudfoundry:<cloudant instance name>",
-      "cloudfoundry:/cloudant/",
+      "cloudfoundry:cloudant",
       "env:kube-cloudant-credentials",
       "file:config/my-cloudant-credentials.json"
     ]


### PR DESCRIPTION
Opted for a more general change so the app can work with both a specific service or if the user is just following the guide, then they can just name their service using cloudant somewhere in the name and it will work. This is just to showcase that the app works with user-provided services. It doesn't add any real code functionality to the app. The user can also still write the name of their service if they want to, so that option is still available. 