### PR TITLE
Remove error return

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Getting started with Swift on IBM Cloud
 To get started, we'll take you through a sample *Getting Started* application that takes only few minutes to deploy.
 
-In order to deploy to IBM Cloud, you'll need an [IBM Cloud account](https://console.ng.bluemix.net/registration/). Once registered, you can automatically deploy the app with toolchain integration using our deploy to IBM Cloud button then skip [here](#5-add-a-database) to set up your cloudant database
+In order to deploy the application to IBM Cloud, you'll need an [IBM Cloud account](https://console.ng.bluemix.net/registration/). Once registered, you can quickly get your app setup remotely using our deploy to IBM Cloud button. Then, simply follow the instructions [here](#5.-Add-a-database) to set up and connect your cloudant database.
 
 [![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM-Cloud/get-started-swift&branch=master)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Getting started with Swift on IBM Cloud
 To get started, we'll take you through a sample *Getting Started* application that takes only few minutes to deploy.
 
-In order to deploy to IBM Cloud, you'll need an [IBM Cloud account](https://console.ng.bluemix.net/registration/). Once registered, you can automatically deploy the app with toolchain integration using our deploy to IBM Cloud button then skip to [Step #5](#5.-Add-a- database) to set up your cloudant database
+In order to deploy to IBM Cloud, you'll need an [IBM Cloud account](https://console.ng.bluemix.net/registration/). Once registered, you can automatically deploy the app with toolchain integration using our deploy to IBM Cloud button then skip [here](#5-add-a-database) to set up your cloudant database
 
 [![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM-Cloud/get-started-swift&branch=master)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Getting started with Swift on IBM Cloud
 To get started, we'll take you through a sample *Getting Started* application that takes only few minutes to deploy.
 
-In order to deploy to IBM Cloud, you'll need an [IBM Cloud account](https://console.ng.bluemix.net/registration/). Once registered, you can automatically deploy the app with toolchain integration using our deploy to IBM Cloud button.
+In order to deploy to IBM Cloud, you'll need an [IBM Cloud account](https://console.ng.bluemix.net/registration/). Once registered, you can automatically deploy the app with toolchain integration using our deploy to IBM Cloud button then skip to [Step #5](#5.-Add-a- database) to set up your cloudant database
 
 [![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM-Cloud/get-started-swift&branch=master)
 

--- a/Sources/GetStartedApp/Controller.swift
+++ b/Sources/GetStartedApp/Controller.swift
@@ -67,24 +67,24 @@ public class Controller {
     // If no database, return empty array.
     guard let dbMgr = self.dbMgr else {
       Log.warning(">> No database manager.")
-      respondWith(nil, .internalServerError)
+      respondWith([], nil)
       return
     }
-    
+
     dbMgr.getDatabase() { (db: Database?, error: NSError?) in
       guard let db = db else {
         Log.error(">> No database.")
         respondWith(nil, .internalServerError)
         return
       }
-      
+
       db.retrieveAll(includeDocuments: true) { docs, error in
         guard let docs = docs else {
           Log.error(">> Could not read from database or none exists.")
           respondWith(nil, .internalServerError)
           return
         }
-        
+
         Log.info(">> Successfully retrived all docs from db.")
         let names = docs["rows"].map { _, row in
           return row["doc"]["name"].string ?? ""
@@ -112,7 +112,7 @@ public class Controller {
   public func addVisitors(user: [String: String], respondWith: @escaping ([String: String]?, RequestError?) -> Void) {
     guard let name = user["name"], let dbMgr = self.dbMgr else {
       Log.warning(">> No database manager.")
-      respondWith(nil, .internalServerError)
+      respondWith(["response": "Hello \(user["name"] ?? "")!"], .internalServerError)
       return
     }
 
@@ -122,7 +122,7 @@ public class Controller {
         respondWith(nil, .internalServerError)
         return
       }
-      
+
       db.create(JSON(user), callback: { (id: String?, rev: String?, document: JSON?, error: NSError?) in
         if let error = error {
           Log.error(">> Could not persist document to database.")


### PR DESCRIPTION
In order to keep aligned with previous functionality, when there is no database, the server routes return usable data responses, rather than an error 